### PR TITLE
Add workflow to update flasher latest.json and generate manifest script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,3 +138,31 @@ jobs:
           prerelease: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Checkout flasher repo
+        uses: actions/checkout@v4
+        with:
+          repository: jantielens/inkplate-dashboard-flasher
+          token: ${{ secrets.FLASHER_REPO_TOKEN }}
+          path: flasher
+
+      - name: Build and publish latest.json
+        env:
+          TAG: ${{ steps.get_version.outputs.tag }}
+        run: |
+          set -euo pipefail
+
+          # Use helper script to generate the manifest with friendly names
+          chmod +x scripts/generate_latest_json.sh
+          scripts/generate_latest_json.sh "${TAG}" artifacts flasher/latest.json
+
+          cd flasher
+          git config user.email "actions@github.com"
+          git config user.name "GitHub Action"
+          if [ -n "$(git status --porcelain)" ]; then
+            git add latest.json
+            git commit -m "Update latest.json for ${TAG} [skip ci]"
+            git push
+          else
+            echo "No changes to latest.json"
+          fi

--- a/.github/workflows/update-latest-json.yml
+++ b/.github/workflows/update-latest-json.yml
@@ -1,0 +1,76 @@
+name: Update Flasher latest.json
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'The release tag to generate latest.json for (e.g. v1.2.3)'
+        required: true
+        default: ''
+
+jobs:
+  update:
+    name: Update latest.json in flasher repo
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set tag variable
+        id: set_tag
+        run: |
+          TAG=${{ github.event.inputs.tag }}
+          # strip leading v if present for the script, but keep original tag for release path
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+
+      - name: Download release artifacts
+        run: |
+          set -euo pipefail
+          TAG=${{ steps.set_tag.outputs.tag }}
+          mkdir -p artifacts
+          echo "Downloading artifacts for $TAG"
+          # Download all .bin files attached to the release
+          gh release download "$TAG" --pattern "*.bin" -D artifacts
+
+      - name: Verify artifacts found
+        run: |
+          if [ -z "$(ls -A artifacts 2>/dev/null)" ]; then
+            echo "No artifacts found in artifacts/"
+            ls -la artifacts || true
+            exit 1
+          fi
+
+      - name: Checkout flasher repo
+        uses: actions/checkout@v4
+        with:
+          repository: jantielens/inkplate-dashboard-flasher
+          token: ${{ secrets.FLASHER_REPO_TOKEN }}
+          path: flasher
+
+      - name: Ensure jq is installed
+        run: |
+          sudo apt-get update && sudo apt-get install -y jq
+
+      - name: Generate latest.json
+        run: |
+          TAG=${{ steps.set_tag.outputs.tag }}
+          chmod +x scripts/generate_latest_json.sh
+          scripts/generate_latest_json.sh "${TAG}" artifacts flasher/latest.json
+
+      - name: Commit and push latest.json if changed
+        env:
+          TAG: ${{ steps.set_tag.outputs.tag }}
+        run: |
+          cd flasher
+          git config user.email "actions@github.com"
+          git config user.name "GitHub Action"
+          if [ -n "$(git status --porcelain)" ]; then
+            git add latest.json
+            git commit -m "Update latest.json for ${TAG} [skip ci]"
+            git push
+          else
+            echo "No changes to latest.json"
+          fi

--- a/scripts/generate_latest_json.sh
+++ b/scripts/generate_latest_json.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Generate latest.json manifest for flasher repo
+# Usage: generate_latest_json.sh <tag> <artifacts_dir> <output_path>
+set -euo pipefail
+
+TAG=${1:-}
+ARTIFACTS_DIR=${2:-artifacts}
+OUT_FILE=${3:-latest.json}
+
+if [ -z "$TAG" ]; then
+  echo "Usage: $0 <tag> [artifacts_dir] [output_path]"
+  exit 2
+fi
+
+PUBLISHED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+# ensure jq exists
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required but not installed. Please install jq."
+  exit 1
+fi
+
+# Friendly display names for boards
+declare -A NAMES
+NAMES[inkplate2]="Inkplate 2"
+NAMES[inkplate5v2]="Inkplate 5 V2"
+NAMES[inkplate10]="Inkplate 10"
+NAMES[inkplate6flick]="Inkplate 6 Flick"
+
+TMP=$(mktemp)
+trap 'rm -f "$TMP"' EXIT
+
+jq -n --arg tag "$TAG" --arg published_at "$PUBLISHED_AT" '{tag_name: $tag, published_at: $published_at, assets: []}' > "$TMP"
+
+for f in "$ARTIFACTS_DIR"/*.bin; do
+  [ -f "$f" ] || continue
+  filename=$(basename "$f")
+    # sanitize inputs (remove CR and LF)
+    filename=$(printf "%s" "$filename" | tr -d '\r\n')
+    TAG=$(printf "%s" "$TAG" | tr -d '\r\n')
+  board=$(echo "$filename" | sed -E 's/-v.*//')
+  url="https://github.com/jantielens/inkplate-dashboard/releases/download/${TAG}/${filename}"
+  # remove any stray CR/LF that may exist in variables
+  url=$(printf "%s" "$url" | tr -d '\r\n')
+  display_name="${NAMES[$board]:-$board}"
+  # append asset
+  jq --arg board "$board" --arg filename "$filename" --arg url "$url" --arg display_name "$display_name" '.assets += [{board: $board, filename: $filename, url: $url, display_name: $display_name}]' "$TMP" > "$TMP.tmp" && mv "$TMP.tmp" "$TMP"
+done
+
+# sort assets by board for determinism
+jq '.assets |= sort_by(.board)' "$TMP" > "$TMP.tmp" && mv "$TMP.tmp" "$TMP"
+
+mv "$TMP" "$OUT_FILE"
+
+echo "Generated $OUT_FILE"


### PR DESCRIPTION
This pull request introduces automation for generating and updating the `latest.json` manifest in the flasher repository as part of the release process. It adds a new workflow for manual updates, integrates the manifest generation into the release workflow, and provides a helper script for building the manifest from release artifacts.

**Release workflow enhancements:**

* Updated `.github/workflows/release.yml` to automatically checkout the flasher repo and build/publish `latest.json` during releases, committing changes if needed.

**New workflow for manual updates:**

* Added `.github/workflows/update-latest-json.yml`, a workflow that allows manual triggering to generate and update `latest.json` in the flasher repo for any specified release tag. This workflow checks out both repos, downloads release artifacts, generates the manifest, and commits changes.

**Manifest generation tooling:**

* Introduced `scripts/generate_latest_json.sh`, a script that creates a `latest.json` manifest from release artifacts, mapping board names to friendly display names and ensuring determinism by sorting assets.