### PR TITLE
feat: Add ESP Web Tools web flasher with automated manifest generation

### DIFF
--- a/.github/workflows/flasher-static-site.yml
+++ b/.github/workflows/flasher-static-site.yml
@@ -8,6 +8,12 @@ on:
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
+  
+  # Automatically redeploy when a release is published
+  workflow_run:
+    workflows: ["Create Release"]
+    types:
+      - completed
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
@@ -31,6 +37,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: main-flasher
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Upload artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,11 +68,14 @@ jobs:
           chmod +x build.sh
           ./build.sh ${{ matrix.board }}
       
-      - name: Upload firmware artifact
+      - name: Upload firmware artifacts (all binaries)
         uses: actions/upload-artifact@v4
         with:
           name: firmware-${{ matrix.board }}-${{ steps.get_version.outputs.version }}
-          path: build/${{ matrix.board }}/${{ matrix.board }}-v${{ steps.get_version.outputs.version }}.bin
+          path: |
+            build/${{ matrix.board }}/${{ matrix.board }}-v${{ steps.get_version.outputs.version }}.bin
+            build/${{ matrix.board }}/${{ matrix.board }}-v${{ steps.get_version.outputs.version }}.bootloader.bin
+            build/${{ matrix.board }}/${{ matrix.board }}-v${{ steps.get_version.outputs.version }}.partitions.bin
           retention-days: 90
           if-no-files-found: error
 
@@ -139,34 +142,60 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Checkout flasher repo
-        uses: actions/checkout@v4
-        with:
-          repository: jantielens/inkplate-dashboard-flasher
-          token: ${{ secrets.FLASHER_REPO_TOKEN }}
-          path: flasher
-
       - name: Ensure jq is installed
         run: |
           sudo apt-get update && sudo apt-get install -y jq
 
-      - name: Build and publish latest.json
+      - name: Generate web flasher manifests
         env:
           TAG: ${{ steps.get_version.outputs.tag }}
         run: |
           set -euo pipefail
+          
+          # Generate ESP Web Tools manifests for each board
+          chmod +x scripts/generate_manifests.sh
+          scripts/generate_manifests.sh "${TAG}" artifacts flasher
+          
+          echo "Generated manifests:"
+          ls -l flasher/manifest_*.json
 
+      - name: Generate latest.json metadata
+        env:
+          TAG: ${{ steps.get_version.outputs.tag }}
+        run: |
+          set -euo pipefail
+          
           # Use helper script to generate the manifest with friendly names
           chmod +x scripts/generate_latest_json.sh
           scripts/generate_latest_json.sh "${TAG}" artifacts flasher/latest.json
+          
+          echo "Generated latest.json:"
+          ls -l flasher/latest.json
 
-          cd flasher
+      - name: Commit manifests to main-flasher branch
+        env:
+          TAG: ${{ steps.get_version.outputs.tag }}
+        run: |
+          set -euo pipefail
+          
+          # Configure git
           git config user.email "actions@github.com"
           git config user.name "GitHub Action"
+          
+          # Fetch and checkout main-flasher branch
+          git fetch origin main-flasher
+          git checkout main-flasher
+          
+          # Copy generated manifests to flasher directory
+          # (they were generated in the current branch, now copy to main-flasher)
+          git checkout ${{ github.ref_name }} -- flasher/manifest_*.json flasher/latest.json
+          
+          # Commit and push if there are changes
           if [ -n "$(git status --porcelain)" ]; then
-            git add latest.json
-            git commit -m "Update latest.json for ${TAG} [skip ci]"
-            git push
+            git add flasher/manifest_*.json flasher/latest.json
+            git commit -m "Update flasher manifests for ${TAG} [skip ci]"
+            git push origin main-flasher
+            echo "✅ Manifests committed to main-flasher branch"
           else
-            echo "No changes to latest.json"
+            echo "No changes to flasher files"
           fi

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,11 @@ __pycache__/
 venv/
 ENV/
 
+# Flasher - local testing files (keep production manifests)
+flasher/*_local.json
+flasher/builds/
+flasher/latest.json
+
 # Node
 node_modules/
 npm-debug.log*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,21 @@
 
 ## [Unreleased]
 
+## [0.14.0] - 2025-10-22
+
+### Added
+- Web-based firmware flasher using ESP Web Tools
+  - Flash firmware directly from browser (Chrome/Edge) without installing software
+  - Support for all 4 Inkplate boards (2, 5 V2, 6 Flick, 10)
+  - Complete 3-part flashing: bootloader, partition table, and firmware
+  - Automated manifest generation via GitHub Actions on release
+  - Local testing environment for development
+  - Responsive UI with dark mode support and comprehensive troubleshooting guide
+
+### Changed
+- Build system now generates versioned bootloader and partition binaries for web flasher support
+- Release workflow updated to automatically generate and publish ESP Web Tools manifests
+
 ## [0.13.0] - 2025-10-21
 
 ### Added

--- a/build.sh
+++ b/build.sh
@@ -129,19 +129,32 @@ build_board() {
     fi
     
     if [ $BUILD_RESULT -eq 0 ]; then
-        # Rename binary to include version
+        # Copy and rename all binaries to include version (for web flasher)
         ORIGINAL_BIN="$BUILD_DIR/${BOARD_KEY}.ino.bin"
+        ORIGINAL_BOOTLOADER="$BUILD_DIR/${BOARD_KEY}.ino.bootloader.bin"
+        ORIGINAL_PARTITIONS="$BUILD_DIR/${BOARD_KEY}.ino.partitions.bin"
+        
         VERSIONED_BIN="$BUILD_DIR/${BOARD_KEY}-v${FIRMWARE_VERSION}.bin"
+        VERSIONED_BOOTLOADER="$BUILD_DIR/${BOARD_KEY}-v${FIRMWARE_VERSION}.bootloader.bin"
+        VERSIONED_PARTITIONS="$BUILD_DIR/${BOARD_KEY}-v${FIRMWARE_VERSION}.partitions.bin"
         
         if [ -f "$ORIGINAL_BIN" ]; then
             cp "$ORIGINAL_BIN" "$VERSIONED_BIN"
-            echo "✅ Build successful!"
-            echo "Build artifacts: $BUILD_DIR"
-            echo "Firmware binary: ${BOARD_KEY}-v${FIRMWARE_VERSION}.bin"
-        else
-            echo "✅ Build successful (binary not found for renaming)!"
-            echo "Build artifacts: $BUILD_DIR"
+            echo "✅ Copied firmware: ${BOARD_KEY}-v${FIRMWARE_VERSION}.bin"
         fi
+        
+        if [ -f "$ORIGINAL_BOOTLOADER" ]; then
+            cp "$ORIGINAL_BOOTLOADER" "$VERSIONED_BOOTLOADER"
+            echo "✅ Copied bootloader: ${BOARD_KEY}-v${FIRMWARE_VERSION}.bootloader.bin"
+        fi
+        
+        if [ -f "$ORIGINAL_PARTITIONS" ]; then
+            cp "$ORIGINAL_PARTITIONS" "$VERSIONED_PARTITIONS"
+            echo "✅ Copied partitions: ${BOARD_KEY}-v${FIRMWARE_VERSION}.partitions.bin"
+        fi
+        
+        echo "✅ Build successful!"
+        echo "Build artifacts: $BUILD_DIR"
         return 0
     else
         echo "❌ Build failed!"

--- a/common/src/version.h
+++ b/common/src/version.h
@@ -8,9 +8,9 @@
 // - PATCH: Bug fixes (backward compatible fixes)
 
 #define FIRMWARE_VERSION_MAJOR 0
-#define FIRMWARE_VERSION_MINOR 13
+#define FIRMWARE_VERSION_MINOR 14
 #define FIRMWARE_VERSION_PATCH 0
 
-#define FIRMWARE_VERSION "0.13.0"
+#define FIRMWARE_VERSION "0.14.0"
 
 #endif // VERSION_H

--- a/docs/dev/BUILD_SYSTEM.md
+++ b/docs/dev/BUILD_SYSTEM.md
@@ -201,13 +201,42 @@ foreach ($file in $commonSrcFiles) {
 - Prevents confusion (single source of truth in `common/`)
 - Only temporary files for build process
 
-#### 6. **Output Build Artifacts**
+#### 6. **Copy Versioned Binaries**
+
+For web flasher support, the build script creates versioned copies of all binaries:
+
+```bash
+# Copy and rename all binaries to include version
+VERSIONED_BIN="$BUILD_DIR/${BOARD_KEY}-v${FIRMWARE_VERSION}.bin"
+VERSIONED_BOOTLOADER="$BUILD_DIR/${BOARD_KEY}-v${FIRMWARE_VERSION}.bootloader.bin"
+VERSIONED_PARTITIONS="$BUILD_DIR/${BOARD_KEY}-v${FIRMWARE_VERSION}.partitions.bin"
+
+cp "$ORIGINAL_BIN" "$VERSIONED_BIN"
+cp "$ORIGINAL_BOOTLOADER" "$VERSIONED_BOOTLOADER"
+cp "$ORIGINAL_PARTITIONS" "$VERSIONED_PARTITIONS"
+```
+
+**Why three binaries?**
+- **Bootloader** - ESP32 first-stage bootloader (flashed at 0x1000)
+- **Partitions** - Partition table defining memory layout (flashed at 0x8000)
+- **Firmware** - Main application code (flashed at 0x10000)
+
+This matches standard ESP32 flashing with `arduino-cli upload` or `esptool.py` and enables web-based flashing through ESP Web Tools.
+
+See [WEB_FLASHER.md](WEB_FLASHER.md) for details on the web flasher implementation.
+
+#### 7. **Output Build Artifacts**
 ```
 build/inkplate5v2/
-├── inkplate5v2.ino.bin       # Main firmware binary
-├── inkplate5v2.ino.elf       # Debugging symbols
-├── inkplate5v2.ino.map       # Memory map
-└── partitions.csv            # Partition table
+├── inkplate5v2.ino.bin                    # Main firmware binary
+├── inkplate5v2.ino.bootloader.bin         # Bootloader
+├── inkplate5v2.ino.partitions.bin         # Partition table
+├── inkplate5v2-v0.13.0.bin                # Versioned firmware (for releases)
+├── inkplate5v2-v0.13.0.bootloader.bin     # Versioned bootloader (for releases)
+├── inkplate5v2-v0.13.0.partitions.bin     # Versioned partitions (for releases)
+├── inkplate5v2.ino.elf                    # Debugging symbols
+├── inkplate5v2.ino.map                    # Memory map
+└── partitions.csv                         # Partition table source
 ```
 
 ## How Code Sharing Works

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -5,6 +5,8 @@ This section contains documentation for developers, contributors, and maintainer
 | File | Description |
 |------|-------------|
 | [BUILD_SYSTEM.md](BUILD_SYSTEM.md) | Documentation for the custom build system and workflow |
+| [RELEASE_WORKFLOW.md](RELEASE_WORKFLOW.md) | Complete release workflow from feature development to production deployment |
+| [WEB_FLASHER.md](WEB_FLASHER.md) | Web-based firmware flasher implementation using ESP Web Tools |
 | [DISPLAY_CYCLE.md](DISPLAY_CYCLE.md) | Overview of the device's display cycle and runtime flow |
 
 **Architecture Decision Records & Reports**

--- a/docs/dev/RELEASE_WORKFLOW.md
+++ b/docs/dev/RELEASE_WORKFLOW.md
@@ -1,0 +1,646 @@
+# Release and Deployment Workflow
+
+## Overview
+
+This document describes the complete workflow from feature development to production deployment, including all GitHub Actions workflows, scripts, and their interactions.
+
+## Workflow Architecture
+
+```
+Feature Branch
+    │
+    ├─ Development & Testing
+    │
+    ▼
+  main (PR merge)
+    │
+    ├─ Version Check
+    ├─ Build Validation
+    │
+    ▼
+  Create Tag (v0.14.0)
+    │
+    ▼
+  Release Workflow
+    │
+    ├─ Build all boards (4 × 3 binaries)
+    ├─ Create GitHub Release
+    ├─ Generate manifests
+    ├─ Commit to main-flasher
+    │
+    ▼
+  Flasher Deployment (auto-triggered)
+    │
+    ├─ Deploy flasher to GitHub Pages
+    │
+    ▼
+  Users can flash from browser
+```
+
+## The Complete Flow
+
+### 1. Feature Development
+
+**Branch:** `feature/new-feature` or similar
+
+**Activities:**
+- Develop new features
+- Update version in `common/src/version.h` if needed
+- Update `CHANGELOG.md`
+- Test locally with `./build.sh all`
+
+**Local Testing:**
+```bash
+# Build all boards
+./build.sh all
+
+# Test flasher locally (optional)
+./scripts/setup_local_testing.sh
+cd flasher && python3 -m http.server 8080
+```
+
+### 2. Pull Request to main
+
+**Branch:** `feature/new-feature` → `main`
+
+**Triggered Workflows:**
+
+#### A. Version Check (`.github/workflows/version-check.yml`)
+```yaml
+on:
+  pull_request:
+    branches: [main]
+```
+
+**What it does:**
+1. Extracts version from `common/src/version.h`
+2. Checks if version tag already exists
+3. Validates CHANGELOG.md has entry for this version
+4. Fails PR if version already released
+
+**Purpose:** Prevents accidentally releasing same version twice
+
+#### B. Build Validation (`.github/workflows/build.yml`)
+```yaml
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+```
+
+**What it does:**
+1. Builds all 4 boards in parallel
+2. Validates compilation succeeds
+3. Checks firmware size fits in memory
+4. Uploads build artifacts (for testing)
+
+**Purpose:** Catch build errors before merge
+
+### 3. Merge to main
+
+**Action:** PR approved and merged
+
+**What happens:**
+- Feature branch merged into `main`
+- Build workflow runs again on `main` branch
+- Code is now ready for release
+
+**Next step:** Create release tag
+
+### 4. Create Release Tag
+
+**Manual step:**
+
+```bash
+# Ensure version.h and CHANGELOG.md are updated
+git checkout main
+git pull
+
+# Create and push tag (must match version in version.h)
+git tag v0.14.0
+git push origin v0.14.0
+```
+
+**Automated alternative (`.github/workflows/create-tag.yml`):**
+```yaml
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release (e.g., 0.14.0)'
+```
+
+This workflow:
+1. Creates tag from `main` branch
+2. Pushes tag to repository
+3. Automatically triggers release workflow
+
+### 5. Release Workflow
+
+**Triggered by:** Tag push (`v*.*.*`)
+
+**Workflow:** `.github/workflows/release.yml`
+
+#### Step 1: Build All Boards (Parallel)
+
+**Strategy:**
+```yaml
+strategy:
+  matrix:
+    board: [inkplate2, inkplate5v2, inkplate10, inkplate6flick]
+```
+
+**For each board:**
+1. Install Arduino CLI and dependencies
+2. Run `./build.sh <board>`
+3. Generates 3 binaries:
+   - `inkplate2-v0.14.0.bin` (firmware)
+   - `inkplate2-v0.14.0.bootloader.bin`
+   - `inkplate2-v0.14.0.partitions.bin`
+4. Upload as artifacts
+
+**Output:** 12 binary files total (4 boards × 3 files)
+
+#### Step 2: Create GitHub Release
+
+**Dependencies:** Wait for all builds to complete
+
+**Actions:**
+1. Download all build artifacts
+2. Extract CHANGELOG section for this version
+3. Create GitHub Release with:
+   - Tag: `v0.14.0`
+   - Name: `Release v0.14.0`
+   - Body: Changelog excerpt
+   - Assets: All 12 binary files
+   - Published (not draft)
+
+**Result:** Users can download binaries from GitHub Releases page
+
+#### Step 3: Generate Web Flasher Manifests
+
+**Script:** `scripts/generate_manifests.sh`
+
+**What it does:**
+```bash
+./scripts/generate_manifests.sh v0.14.0 artifacts flasher
+```
+
+For each board:
+1. Finds the 3 binary files in artifacts
+2. Creates ESP Web Tools manifest JSON:
+   ```json
+   {
+     "name": "Inkplate Dashboard for Inkplate 2",
+     "version": "0.14.0",
+     "builds": [{
+       "chipFamily": "ESP32",
+       "parts": [
+         {
+           "path": "https://github.com/.../inkplate2-v0.14.0.bootloader.bin",
+           "offset": 4096
+         },
+         {
+           "path": "https://github.com/.../inkplate2-v0.14.0.partitions.bin",
+           "offset": 32768
+         },
+         {
+           "path": "https://github.com/.../inkplate2-v0.14.0.bin",
+           "offset": 65536
+         }
+       ]
+     }]
+   }
+   ```
+3. Saves as `flasher/manifest_inkplate2.json`
+
+**Output:** 4 manifest files pointing to GitHub Release URLs
+
+#### Step 4: Generate Latest Metadata
+
+**Script:** `scripts/generate_latest_json.sh`
+
+**What it does:**
+```bash
+./scripts/generate_latest_json.sh v0.14.0 artifacts flasher/latest.json
+```
+
+Creates `flasher/latest.json`:
+```json
+{
+  "tag_name": "v0.14.0",
+  "published_at": "2025-10-22T12:00:00Z",
+  "assets": [
+    {
+      "board": "inkplate2",
+      "filename": "inkplate2-v0.14.0.bin",
+      "url": "https://github.com/.../inkplate2-v0.14.0.bin",
+      "bootloader_url": "https://github.com/.../bootloader.bin",
+      "partitions_url": "https://github.com/.../partitions.bin",
+      "display_name": "Inkplate 2"
+    }
+    // ... more boards
+  ]
+}
+```
+
+**Purpose:** Provides API for flasher site to discover available firmware
+
+#### Step 5: Commit Manifests to main-flasher
+
+**Critical step:** Manifests must be on `main-flasher` branch for GitHub Pages
+
+**Actions:**
+```bash
+# Configure git
+git config user.email "actions@github.com"
+git config user.name "GitHub Action"
+
+# Fetch and checkout main-flasher branch
+git fetch origin main-flasher
+git checkout main-flasher
+
+# Copy generated manifests from release branch
+git checkout ${{ github.ref_name }} -- flasher/manifest_*.json flasher/latest.json
+
+# Commit and push
+git add flasher/manifest_*.json flasher/latest.json
+git commit -m "Update flasher manifests for v0.14.0 [skip ci]"
+git push origin main-flasher
+```
+
+**Why main-flasher?**
+- GitHub Pages is configured to deploy from `main-flasher` branch
+- Keeps flasher site separate from main codebase
+- Manifests are where the deployment workflow expects them
+
+**Note:** `[skip ci]` prevents infinite workflow loops
+
+### 6. Flasher Deployment (Automatic)
+
+**Triggered by:** Release workflow completion
+
+**Workflow:** `.github/workflows/flasher-static-site.yml`
+
+**Trigger configuration:**
+```yaml
+on:
+  push:
+    branches: ["main-flasher"]  # Manual commits
+  workflow_run:
+    workflows: ["Create Release"]  # After release completes
+    types:
+      - completed
+  workflow_dispatch:  # Manual trigger
+```
+
+**What it does:**
+1. Checks out `main-flasher` branch (explicitly)
+2. Uploads `/flasher` directory as Pages artifact
+3. Deploys to GitHub Pages
+
+**Deployment:**
+- **URL:** `https://jantielens.github.io/inkplate-dashboard/`
+- **Contains:**
+  - `index.html` - Web flasher UI
+  - `manifest_*.json` - Board-specific manifests (just updated)
+  - `latest.json` - Metadata (just updated)
+  - `README.md` - Documentation
+
+**Result:** Users can visit the site and flash firmware directly from browser
+
+### 7. User Experience
+
+**User visits:** `https://jantielens.github.io/inkplate-dashboard/`
+
+**Flow:**
+1. Page loads, reads `latest.json` to show latest version
+2. User selects their board (Inkplate 2, 5 V2, 6 Flick, or 10)
+3. JavaScript loads appropriate manifest (`manifest_inkplate2.json`)
+4. User clicks "Install Inkplate Dashboard"
+5. Browser prompts for serial port selection
+6. ESP Web Tools:
+   - Downloads 3 binaries from GitHub Releases
+   - Flashes bootloader → partitions → firmware
+   - Verifies flash
+7. Device restarts with new firmware
+8. Done! ✅
+
+## Scripts Reference
+
+### Build Scripts
+
+#### `build.sh`
+**Purpose:** Build firmware for one or all boards
+
+**Usage:**
+```bash
+./build.sh inkplate2          # Build specific board
+./build.sh all                # Build all boards
+```
+
+**What it does:**
+1. Copies common `.cpp` files to board directory
+2. Runs `arduino-cli compile` with correct FQBN
+3. Generates 3 binaries with version numbers
+4. Cleans up copied files
+
+**Output location:** `build/<board>/`
+
+#### `upload.ps1`
+**Purpose:** Upload firmware to connected device (development)
+
+**Usage:**
+```powershell
+.\upload.ps1 -Board inkplate2 -Port COM7
+```
+
+**Not used in CI/CD** - only for local development
+
+### Release Scripts
+
+#### `scripts/generate_manifests.sh`
+**Purpose:** Generate ESP Web Tools manifest files
+
+**Usage:**
+```bash
+./scripts/generate_manifests.sh v0.14.0 artifacts flasher
+```
+
+**Arguments:**
+- `v0.14.0` - Version tag
+- `artifacts` - Directory containing binaries
+- `flasher` - Output directory
+
+**Creates:**
+- `flasher/manifest_inkplate2.json`
+- `flasher/manifest_inkplate5v2.json`
+- `flasher/manifest_inkplate6flick.json`
+- `flasher/manifest_inkplate10.json`
+
+#### `scripts/generate_latest_json.sh`
+**Purpose:** Generate metadata file for flasher site
+
+**Usage:**
+```bash
+./scripts/generate_latest_json.sh v0.14.0 artifacts flasher/latest.json
+```
+
+**Creates:** `flasher/latest.json` with release info
+
+#### `scripts/prepare_release.sh`
+**Purpose:** Manual release preparation (alternative to CI/CD)
+
+**Usage:**
+```bash
+./scripts/prepare_release.sh v0.14.0
+```
+
+**What it does:**
+1. Builds all boards
+2. Copies binaries to `artifacts/`
+3. Generates all manifests
+4. Shows summary and next steps
+
+**Use case:** Manual releases or pre-flight testing
+
+### Local Testing Scripts
+
+#### `scripts/setup_local_testing.sh`
+**Purpose:** Setup local flasher testing environment
+
+**Usage:**
+```bash
+./scripts/setup_local_testing.sh
+```
+
+**What it does:**
+1. Creates `flasher/builds/` directory structure
+2. Copies binaries from `build/*/` to `flasher/builds/*/`
+3. Generates local manifests pointing to `builds/` directory
+
+**After running:**
+```bash
+cd flasher
+python3 -m http.server 8080
+# Visit http://localhost:8080
+```
+
+## Workflow States & Branches
+
+### Branch Strategy
+
+```
+main (default branch)
+├── Protected
+├── Requires PR
+├── CI/CD validates builds
+└── Source of truth for releases
+
+main-flasher (deployment branch)
+├── Contains flasher site
+├── Manifests committed here by release workflow
+├── Deployed to GitHub Pages
+└── Auto-updated on release
+
+feature/* (development branches)
+├── Created from main
+├── Merged via PR
+└── Deleted after merge
+```
+
+### File Locations by Branch
+
+**main branch:**
+- Source code (`boards/`, `common/`)
+- Build system (`build.sh`, `build.ps1`)
+- Scripts (`scripts/`)
+- Workflows (`.github/workflows/`)
+- Base flasher (`flasher/index.html`, `flasher/README.md`)
+- ❌ NO manifests (generated during release)
+
+**main-flasher branch:**
+- Flasher site (`flasher/`)
+- ✅ Manifests (`flasher/manifest_*.json`)
+- ✅ Metadata (`flasher/latest.json`)
+- Deployed to GitHub Pages
+
+## GitHub Actions Workflows Summary
+
+| Workflow | Trigger | Purpose | Output |
+|----------|---------|---------|--------|
+| `version-check.yml` | PR to main | Validate version is new | PR check ✓/✗ |
+| `build.yml` | PR/push to main | Validate builds | Build artifacts |
+| `create-tag.yml` | Manual dispatch | Create release tag | Git tag |
+| `release.yml` | Tag push `v*.*.*` | Build & release | GitHub Release + Manifests |
+| `flasher-static-site.yml` | Push to main-flasher<br>Release completion | Deploy flasher | GitHub Pages site |
+| `update-latest-json.yml` | Legacy/unused | Old manifest update | N/A |
+
+## Troubleshooting
+
+### Manifests not updating on flasher site
+
+**Symptoms:** Old version shown on flasher site after release
+
+**Cause:** Manifests not committed to `main-flasher` branch
+
+**Fix:**
+1. Check release workflow logs
+2. Verify manifests committed to `main-flasher`
+3. Check flasher deployment workflow ran
+4. Manual fix:
+   ```bash
+   git checkout main-flasher
+   git pull
+   # Verify manifests are present
+   ls flasher/manifest_*.json
+   ```
+
+### Release workflow fails at manifest commit
+
+**Symptoms:** Release succeeds but manifests not committed
+
+**Cause:** Git conflicts or permissions issue
+
+**Fix:**
+1. Check workflow logs for error message
+2. Verify no manual changes on `main-flasher` conflicting
+3. Manual commit if needed:
+   ```bash
+   # Generate manifests locally
+   ./scripts/prepare_release.sh v0.14.0
+   
+   # Commit to main-flasher
+   git checkout main-flasher
+   git pull
+   cp flasher/manifest_*.json flasher/latest.json ../
+   git add manifest_*.json latest.json
+   git commit -m "Update flasher manifests for v0.14.0"
+   git push
+   ```
+
+### Flasher deployment doesn't trigger
+
+**Symptoms:** Release completes but flasher site not updated
+
+**Cause:** `workflow_run` trigger not firing
+
+**Fix:**
+1. Manually trigger deployment:
+   - Go to Actions tab
+   - Select "Deploy static content to Pages"
+   - Click "Run workflow"
+   - Select `main-flasher` branch
+2. Check workflow permissions in repository settings
+
+### Binary files not found during manifest generation
+
+**Symptoms:** Manifest generation fails with "file not found"
+
+**Cause:** Build artifacts not uploaded correctly
+
+**Fix:**
+1. Check build job logs
+2. Verify all 12 binaries created
+3. Check artifact upload step
+4. Verify artifact download in release job
+
+## Best Practices
+
+### Before Creating a Release
+
+1. ✅ Update `common/src/version.h`
+2. ✅ Update `CHANGELOG.md` with new version section
+3. ✅ Test builds locally: `./build.sh all`
+4. ✅ Merge to main via PR
+5. ✅ Wait for CI checks to pass
+6. ✅ Create and push tag
+
+### Version Numbers
+
+Follow semantic versioning:
+- **MAJOR.MINOR.PATCH** (e.g., `0.14.0`)
+- **MAJOR:** Breaking changes
+- **MINOR:** New features (backward compatible)
+- **PATCH:** Bug fixes
+
+### CHANGELOG.md Format
+
+```markdown
+## [0.14.0] - 2025-10-22
+
+### Added
+- New features listed here
+
+### Changed
+- Modified features listed here
+
+### Fixed
+- Bug fixes listed here
+```
+
+### Commit Messages
+
+- Release workflow: `Update flasher manifests for v0.14.0 [skip ci]`
+- Feature branch: `feat: add new feature`
+- Bug fix: `fix: resolve issue with X`
+
+## Manual Override Procedures
+
+### Emergency Manual Release
+
+If CI/CD fails, you can manually create a release:
+
+```bash
+# 1. Build all boards locally
+./scripts/prepare_release.sh v0.14.0
+
+# 2. Manually create GitHub Release
+gh release create v0.14.0 \
+  --title "Release v0.14.0" \
+  --notes-file release_notes.md \
+  artifacts/*.bin
+
+# 3. Commit manifests to main-flasher
+git checkout main-flasher
+git pull
+git add flasher/manifest_*.json flasher/latest.json
+git commit -m "Update flasher manifests for v0.14.0"
+git push
+
+# 4. Trigger flasher deployment manually via GitHub Actions UI
+```
+
+### Rollback a Release
+
+To rollback to a previous version:
+
+```bash
+# 1. Checkout main-flasher
+git checkout main-flasher
+git pull
+
+# 2. Revert manifest commit
+git revert <commit-hash>
+
+# 3. Push
+git push
+
+# 4. Flasher will automatically redeploy with previous manifests
+```
+
+**Note:** This only rolls back the flasher site. The GitHub Release remains published.
+
+## Summary
+
+The workflow automates the complete release process from code merge to production deployment:
+
+1. **Developer:** Merges feature to `main` with updated version
+2. **CI/CD:** Validates build on PR
+3. **Developer:** Creates release tag
+4. **Release Workflow:** Builds firmware, creates release, generates manifests
+5. **Flasher Deployment:** Automatically updates web flasher
+6. **Users:** Can immediately flash new version from browser
+
+All workflows are designed to be resilient, with manual override options and clear error messages for troubleshooting.

--- a/docs/dev/WEB_FLASHER.md
+++ b/docs/dev/WEB_FLASHER.md
@@ -1,0 +1,601 @@
+# Web Flasher Implementation
+
+## Overview
+
+The Inkplate Dashboard includes a web-based firmware flasher that allows users to flash their devices directly from a browser without installing any software. It uses [ESP Web Tools](https://esphome.github.io/esp-web-tools/) and the Web Serial API.
+
+## Quick Links
+
+- **Live Flasher:** https://jantielens.github.io/inkplate-dashboard/flasher/
+- **Local Testing:** `./scripts/setup_local_testing.sh` then `cd flasher && python3 -m http.server 8080`
+- **ESP Web Tools Docs:** https://esphome.github.io/esp-web-tools/
+
+## Architecture
+
+### High-Level Flow
+
+```
+┌─────────────┐
+│   Browser   │ (Chrome/Edge - Web Serial API required)
+└──────┬──────┘
+       │ 1. User selects board
+       ▼
+┌─────────────────┐
+│  index.html     │ Loads manifest_inkplate*.json
+│  ESP Web Tools  │
+└────────┬────────┘
+         │ 2. Fetches manifest
+         ▼
+┌──────────────────────┐
+│  manifest_*.json     │ Points to GitHub Release URLs
+└──────────┬───────────┘
+           │ 3. Downloads binaries
+           ▼
+┌─────────────────────────────────────┐
+│  GitHub Releases                     │
+│  - bootloader.bin (offset 0x1000)    │
+│  - partitions.bin (offset 0x8000)    │
+│  - firmware.bin   (offset 0x10000)   │
+└─────────────────┬───────────────────┘
+                  │ 4. Flash via Web Serial
+                  ▼
+           ┌──────────────┐
+           │  ESP32       │
+           │  Inkplate    │
+           └──────────────┘
+```
+
+## Project Structure
+
+```
+flasher/
+├── index.html                    # Web flasher UI
+├── manifest_inkplate2.json       # Production manifest (committed)
+├── manifest_inkplate5v2.json     # Production manifest (committed)
+├── manifest_inkplate6flick.json  # Production manifest (committed)
+├── manifest_inkplate10.json      # Production manifest (committed)
+├── manifest_*_local.json         # Local testing manifests (gitignored)
+├── builds/                       # Local binary copies (gitignored)
+├── latest.json                   # Metadata (generated, gitignored)
+└── README.md                     # Flasher documentation
+
+scripts/
+├── generate_manifests.sh         # Generates ESP Web Tools manifests
+├── generate_latest_json.sh       # Generates metadata
+├── prepare_release.sh            # Manual release preparation
+└── setup_local_testing.sh        # Sets up local testing environment
+```
+
+## How It Works
+
+### 1. Binary Files Required
+
+For each board, three binary files are needed for complete flashing:
+
+| File | Purpose | Memory Offset | Size |
+|------|---------|---------------|------|
+| `bootloader.bin` | ESP32 bootloader | 0x1000 (4096) | ~19KB |
+| `partitions.bin` | Partition table | 0x8000 (32768) | ~3KB |
+| `firmware.bin` | Main application | 0x10000 (65536) | ~1.1MB |
+
+**Why three files?**
+- This matches the standard ESP32 flashing process
+- Same approach used by `arduino-cli upload` and `esptool.py`
+- Allows OTA updates while preserving bootloader
+
+### 2. Build Process
+
+The build system (`build.sh`) automatically generates all three binaries:
+
+```bash
+./build.sh inkplate6flick
+
+# Generates in build/inkplate6flick/:
+# - inkplate6flick-v0.13.0.bin            (firmware)
+# - inkplate6flick-v0.13.0.bootloader.bin
+# - inkplate6flick-v0.13.0.partitions.bin
+```
+
+**Modified in `build.sh`:**
+```bash
+# Copy and rename all binaries to include version
+VERSIONED_BIN="$BUILD_DIR/${BOARD_KEY}-v${FIRMWARE_VERSION}.bin"
+VERSIONED_BOOTLOADER="$BUILD_DIR/${BOARD_KEY}-v${FIRMWARE_VERSION}.bootloader.bin"
+VERSIONED_PARTITIONS="$BUILD_DIR/${BOARD_KEY}-v${FIRMWARE_VERSION}.partitions.bin"
+
+cp "$ORIGINAL_BIN" "$VERSIONED_BIN"
+cp "$ORIGINAL_BOOTLOADER" "$VERSIONED_BOOTLOADER"
+cp "$ORIGINAL_PARTITIONS" "$VERSIONED_PARTITIONS"
+```
+
+### 3. Manifest Files
+
+ESP Web Tools uses JSON manifest files to describe what to flash and where.
+
+**Example: `manifest_inkplate6flick.json`**
+```json
+{
+  "name": "Inkplate Dashboard for Inkplate 6 Flick",
+  "version": "0.13.0",
+  "home_assistant_domain": "inkplate_dashboard",
+  "new_install_prompt_erase": true,
+  "builds": [
+    {
+      "chipFamily": "ESP32",
+      "parts": [
+        {
+          "path": "https://github.com/jantielens/inkplate-dashboard/releases/download/v0.13.0/inkplate6flick-v0.13.0.bootloader.bin",
+          "offset": 4096
+        },
+        {
+          "path": "https://github.com/jantielens/inkplate-dashboard/releases/download/v0.13.0/inkplate6flick-v0.13.0.partitions.bin",
+          "offset": 32768
+        },
+        {
+          "path": "https://github.com/jantielens/inkplate-dashboard/releases/download/v0.13.0/inkplate6flick-v0.13.0.bin",
+          "offset": 65536
+        }
+      ]
+    }
+  ]
+}
+```
+
+**Manifest Fields:**
+- `name` - Display name shown to users
+- `version` - Firmware version
+- `home_assistant_domain` - Optional HA integration
+- `new_install_prompt_erase` - Ask user to erase flash
+- `builds[].chipFamily` - Target chip (ESP32)
+- `builds[].parts[]` - Array of binaries to flash
+  - `path` - URL to binary file
+  - `offset` - Memory address to flash to (decimal)
+
+### 4. Web Interface
+
+**`flasher/index.html`** provides:
+- Board selection UI (4 boards with visual cards)
+- ESP Web Tools integration
+- Automatic local/production mode detection
+- Comprehensive instructions and troubleshooting
+- Dark/light mode support
+- Mobile-responsive design
+
+**Key JavaScript:**
+```javascript
+// Detect environment
+const isLocal = window.location.hostname === 'localhost' || 
+               window.location.hostname === '127.0.0.1' ||
+               window.location.hostname.includes('github.dev');
+
+// Load appropriate manifest
+boardRadios.forEach(radio => {
+  radio.addEventListener('change', (e) => {
+    const boardId = e.target.value;
+    const manifestSuffix = isLocal ? '_local' : '';
+    installButton.manifest = `./manifest_${boardId}${manifestSuffix}.json`;
+    installButton.classList.remove('hidden');
+  });
+});
+```
+
+## Release Workflow
+
+### Automated (GitHub Actions)
+
+When you push a tag (e.g., `v0.14.0`), the workflow automatically:
+
+**`.github/workflows/release.yml`** does:
+
+1. **Build all boards** (matrix strategy):
+   ```yaml
+   strategy:
+     matrix:
+       board: [inkplate2, inkplate5v2, inkplate10, inkplate6flick]
+   ```
+
+2. **Upload all binaries as artifacts**:
+   ```yaml
+   - name: Upload firmware artifacts (all binaries)
+     uses: actions/upload-artifact@v4
+     with:
+       path: |
+         build/${{ matrix.board }}/*-v*.bin
+         build/${{ matrix.board }}/*-v*.bootloader.bin
+         build/${{ matrix.board }}/*-v*.partitions.bin
+   ```
+
+3. **Create GitHub Release** with all 12 binaries (4 boards × 3 files)
+
+4. **Generate manifests**:
+   ```yaml
+   - name: Generate web flasher manifests
+     run: |
+       chmod +x scripts/generate_manifests.sh
+       scripts/generate_manifests.sh "${TAG}" artifacts flasher
+   ```
+
+5. **Commit manifests** to the flasher repo/directory:
+   ```yaml
+   - name: Build and publish latest.json and manifests
+     run: |
+       cd flasher
+       git add latest.json manifest_*.json
+       git commit -m "Update flasher for ${TAG} [skip ci]"
+       git push
+   ```
+
+**Result:** Flasher is automatically updated with new firmware!
+
+### Manual (For Testing)
+
+```bash
+# 1. Prepare everything locally
+./scripts/prepare_release.sh v0.14.0
+
+# This generates:
+# - artifacts/*.bin (all binaries)
+# - flasher/manifest_*.json (production manifests)
+# - flasher/latest.json (metadata)
+
+# 2. Manually create GitHub release and upload artifacts/
+
+# 3. Commit manifests
+git add flasher/manifest_*.json
+git commit -m "Update flasher for v0.14.0"
+git push
+```
+
+## Local Testing
+
+### Setup
+
+```bash
+# 1. Build a board
+./build.sh inkplate6flick
+
+# 2. Setup local testing environment
+./scripts/setup_local_testing.sh
+
+# This creates:
+# - flasher/manifest_*_local.json (points to local files)
+# - flasher/builds/ (copies of binaries)
+
+# 3. Start local server
+cd flasher
+python3 -m http.server 8080
+
+# 4. Open http://localhost:8080 in Chrome/Edge
+```
+
+### How Local Testing Works
+
+**Local manifests** point to relative paths:
+```json
+{
+  "parts": [
+    { "path": "builds/inkplate6flick/inkplate6flick-v0.13.0.bootloader.bin", ... },
+    { "path": "builds/inkplate6flick/inkplate6flick-v0.13.0.partitions.bin", ... },
+    { "path": "builds/inkplate6flick/inkplate6flick-v0.13.0.bin", ... }
+  ]
+}
+```
+
+**Automatic detection in `index.html`:**
+```javascript
+// Detects localhost or github.dev codespaces
+const isLocal = window.location.hostname === 'localhost' || 
+               window.location.hostname === '127.0.0.1' ||
+               window.location.hostname.includes('github.dev');
+
+// Shows warning banner
+if (isLocal) {
+  document.getElementById('local-test-warning').style.display = 'block';
+}
+```
+
+**Files ignored by git** (`.gitignore`):
+```gitignore
+# Flasher - local testing files (keep production manifests)
+flasher/*_local.json
+flasher/builds/
+flasher/latest.json
+```
+
+## Scripts Reference
+
+### `generate_manifests.sh`
+
+**Purpose:** Generate ESP Web Tools manifest files
+
+**Usage:**
+```bash
+./scripts/generate_manifests.sh <tag> <artifacts_dir> <output_dir>
+./scripts/generate_manifests.sh v0.14.0 artifacts flasher
+```
+
+**What it does:**
+1. Scans `artifacts_dir` for versioned binaries
+2. For each board, creates a manifest JSON
+3. URLs point to GitHub Release downloads
+4. Outputs to `output_dir/manifest_<board>.json`
+
+**Manifest generation logic:**
+```bash
+bootloader_url="${base_url}/${board}-v${VERSION}.bootloader.bin"
+partitions_url="${base_url}/${board}-v${VERSION}.partitions.bin"
+firmware_url="${base_url}/${board}-v${VERSION}.bin"
+
+jq -n \
+  --arg name "Inkplate Dashboard for ${display_name}" \
+  --arg version "$VERSION" \
+  --arg bootloader_url "$bootloader_url" \
+  --argjson bootloader_offset "4096" \
+  --arg partitions_url "$partitions_url" \
+  --argjson partitions_offset "32768" \
+  --arg firmware_url "$firmware_url" \
+  --argjson firmware_offset "65536" \
+  '{...manifest structure...}'
+```
+
+### `generate_latest_json.sh`
+
+**Purpose:** Generate metadata for latest release
+
+**Usage:**
+```bash
+./scripts/generate_latest_json.sh <tag> <artifacts_dir> <output_file>
+./scripts/generate_latest_json.sh v0.14.0 artifacts flasher/latest.json
+```
+
+**Output format:**
+```json
+{
+  "tag_name": "v0.14.0",
+  "published_at": "2025-10-22T12:00:00Z",
+  "assets": [
+    {
+      "board": "inkplate2",
+      "filename": "inkplate2-v0.14.0.bin",
+      "url": "https://github.com/.../inkplate2-v0.14.0.bin",
+      "bootloader_url": "https://github.com/.../inkplate2-v0.14.0.bootloader.bin",
+      "partitions_url": "https://github.com/.../inkplate2-v0.14.0.partitions.bin",
+      "display_name": "Inkplate 2"
+    }
+    // ... more boards
+  ]
+}
+```
+
+### `prepare_release.sh`
+
+**Purpose:** Manual release preparation
+
+**Usage:**
+```bash
+./scripts/prepare_release.sh v0.14.0
+```
+
+**Steps:**
+1. Builds all boards: `./build.sh all`
+2. Creates `artifacts/` directory
+3. Copies all binaries to `artifacts/`
+4. Generates manifests: `generate_manifests.sh`
+5. Generates metadata: `generate_latest_json.sh`
+6. Displays summary and next steps
+
+**Use cases:**
+- Testing before creating actual release
+- Manual release process
+- Debugging build/manifest generation
+
+### `setup_local_testing.sh`
+
+**Purpose:** Setup local testing environment
+
+**Usage:**
+```bash
+./scripts/setup_local_testing.sh
+```
+
+**Steps:**
+1. Creates `flasher/builds/` directory structure
+2. Copies binaries from `build/*/` to `flasher/builds/*/`
+3. Generates local manifests pointing to `builds/` directory
+4. Shows instructions for starting local server
+
+**Generated structure:**
+```
+flasher/
+├── builds/
+│   ├── inkplate2/
+│   │   ├── inkplate2-v0.13.0.bin
+│   │   ├── inkplate2-v0.13.0.bootloader.bin
+│   │   └── inkplate2-v0.13.0.partitions.bin
+│   └── ... (other boards)
+├── manifest_inkplate2_local.json
+└── ... (other local manifests)
+```
+
+## Browser Compatibility
+
+### Supported Browsers
+
+| Browser | Version | Status |
+|---------|---------|--------|
+| Chrome | 89+ | ✅ Fully Supported |
+| Edge | 89+ | ✅ Fully Supported |
+| Opera | 75+ | ✅ Fully Supported |
+| Firefox | Any | ❌ Not Supported (no Web Serial) |
+| Safari | Any | ❌ Not Supported (no Web Serial) |
+
+**Why Chrome/Edge only?**
+- Requires [Web Serial API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Serial_API)
+- Firefox and Safari have not implemented it
+- Security concerns prevent it from working on insecure (HTTP) connections
+
+### Requirements
+
+1. **HTTPS or localhost** - Web Serial API requires secure context
+2. **USB drivers** - CP210x drivers for ESP32 serial communication
+3. **Permissions** - User must grant serial port access
+
+## Security & CORS
+
+### How Binary Downloads Work
+
+**Production flow:**
+1. Browser loads `index.html` from GitHub Pages (HTTPS)
+2. Manifest loaded from same origin
+3. Binaries fetched from GitHub Releases (HTTPS)
+4. GitHub serves with appropriate CORS headers
+5. ESP Web Tools downloads and flashes
+
+**Why GitHub Releases work:**
+```
+Access-Control-Allow-Origin: *
+```
+GitHub's CDN allows cross-origin requests, enabling the flasher to download binaries.
+
+**Local testing CORS:**
+- All files served from same Python HTTP server
+- No CORS restrictions (same origin)
+- Works seamlessly for development
+
+## Troubleshooting
+
+### "No 'Access-Control-Allow-Origin' header"
+
+**Cause:** Trying to flash from production site with local binaries
+
+**Solution:** Use local manifests when testing locally
+
+### "404 Not Found" on binary files
+
+**Cause:** Release doesn't have all required binaries
+
+**Solution:** 
+- Ensure release includes bootloader and partition files
+- Check manifest URLs are correct
+- Verify tag matches release version
+
+### Serial port not showing
+
+**Causes:**
+1. USB cable is charge-only (no data)
+2. Missing CP210x drivers
+3. Port in use by another program
+4. Browser doesn't support Web Serial
+
+**Solutions:**
+1. Try different USB cable
+2. Install [CP210x drivers](https://www.silabs.com/developers/usb-to-uart-bridge-vcp-drivers)
+3. Close Arduino IDE, PlatformIO, serial monitors
+4. Use Chrome or Edge browser
+
+### Flash fails partway through
+
+**Causes:**
+1. Device not in bootloader mode
+2. Interrupted connection
+3. Corrupt binary file
+
+**Solutions:**
+1. Press reset button before flashing
+2. Use shorter USB cable
+3. Rebuild firmware
+
+## Best Practices
+
+### Adding New Boards
+
+1. **Update build system:**
+   ```bash
+   # Add to boards/ directory
+   # Update build.sh BOARDS array
+   ```
+
+2. **Update manifest generator:**
+   ```bash
+   # scripts/generate_manifests.sh automatically handles new boards
+   # Just ensure board friendly name in NAMES array
+   ```
+
+3. **Update web interface:**
+   ```html
+   <!-- Add board option in index.html -->
+   <div class="board-option">
+     <input type="radio" name="board" id="newboard" value="newboard" />
+     <label for="newboard">
+       <span class="board-icon">📱</span>
+       New Board
+     </label>
+   </div>
+   ```
+
+### Version Management
+
+- Version is defined in `common/src/version.h`
+- Must match Git tag (enforced by CI)
+- Embedded in firmware and manifest files
+- Displayed in web interface
+
+### Release Checklist
+
+- [ ] Update version in `common/src/version.h`
+- [ ] Update `CHANGELOG.md`
+- [ ] Test builds locally: `./build.sh all`
+- [ ] Commit and push changes
+- [ ] Create and push tag: `git tag v0.x.x && git push origin v0.x.x`
+- [ ] GitHub Actions will handle the rest
+- [ ] Verify release on GitHub
+- [ ] Test flasher with new version
+
+## Future Enhancements
+
+### Potential Improvements
+
+1. **Version Selection**
+   - Allow users to choose from multiple versions
+   - Fetch version list from GitHub API
+   - Add release notes in UI
+
+2. **OTA Update Mode**
+   - Flash only firmware (skip bootloader/partitions)
+   - Faster updates for devices already running dashboard
+   - Preserve configuration
+
+3. **WiFi Pre-Configuration**
+   - Allow users to set WiFi credentials before flashing
+   - Modify firmware image before upload
+   - Skip initial setup portal
+
+4. **Advanced Options**
+   - Erase NVS option
+   - Custom partition tables
+   - Debug builds
+
+5. **Better Analytics**
+   - Track flash success/failure rates
+   - Board usage statistics
+   - Error reporting
+
+## References
+
+- [ESP Web Tools Documentation](https://esphome.github.io/esp-web-tools/)
+- [Web Serial API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Serial_API)
+- [ESP32 Flash Layout](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/partition-tables.html)
+- [esptool.py](https://github.com/espressif/esptool)
+- [Arduino-ESP32](https://github.com/espressif/arduino-esp32)
+
+## Summary
+
+The web flasher provides a user-friendly way to install Inkplate Dashboard firmware without requiring technical knowledge or software installation. It uses industry-standard tools (ESP Web Tools, Web Serial API) and follows ESP32 best practices for flashing.
+
+**Key Benefits:**
+- ✅ No software installation required
+- ✅ Works directly in browser
+- ✅ Automated through GitHub Actions
+- ✅ Easy local testing for development
+- ✅ Matches arduino-cli upload behavior
+- ✅ Professional, polished UI

--- a/flasher/README.md
+++ b/flasher/README.md
@@ -1,0 +1,161 @@
+# Inkplate Dashboard Web Flasher
+
+This directory contains the web-based firmware flasher for Inkplate Dashboard, built using [ESP Web Tools](https://esphome.github.io/esp-web-tools/).
+
+## 🌐 Live Flasher
+
+Visit the web flasher at: **[https://jantielens.github.io/inkplate-dashboard/flasher/](https://jantielens.github.io/inkplate-dashboard/flasher/)**
+
+## 📋 How It Works
+
+The flasher uses the Web Serial API to flash ESP32 devices directly from your browser. No installation required!
+
+### Files
+
+- `index.html` - Main flasher interface with board selection
+- `manifest_*.json` - ESP Web Tools manifest files for each board (generated during release)
+
+## 🔧 For Developers
+
+### Generating Manifests
+
+Manifests are generated automatically during the release process. To manually generate manifests:
+
+```bash
+# Generate manifests from build artifacts
+./scripts/generate_manifests.sh v0.13.0 build/inkplate2 flasher
+
+# Or for all boards from artifacts directory
+./scripts/generate_manifests.sh v0.13.0 artifacts flasher
+```
+
+### Testing Locally
+
+1. Build the firmware for a board:
+   ```bash
+   ./build.sh inkplate2
+   ```
+
+2. Generate the manifest:
+   ```bash
+   ./scripts/generate_manifests.sh v0.13.0 build/inkplate2 flasher
+   ```
+
+3. Start a local web server:
+   ```bash
+   cd flasher
+   python3 -m http.server 8000
+   ```
+
+4. Open `http://localhost:8000` in Chrome/Edge
+
+5. For local testing, temporarily edit the manifest to point to local files:
+   ```json
+   {
+     "parts": [
+       { "path": "/build/inkplate2/inkplate2-v0.13.0.bootloader.bin", "offset": 4096 },
+       ...
+     ]
+   }
+   ```
+
+### Manifest Format
+
+Each manifest file follows the ESP Web Tools specification:
+
+```json
+{
+  "name": "Inkplate Dashboard for Inkplate 2",
+  "version": "0.13.0",
+  "home_assistant_domain": "inkplate_dashboard",
+  "new_install_prompt_erase": true,
+  "builds": [
+    {
+      "chipFamily": "ESP32",
+      "parts": [
+        {
+          "path": "https://github.com/.../bootloader.bin",
+          "offset": 4096
+        },
+        {
+          "path": "https://github.com/.../partitions.bin",
+          "offset": 32768
+        },
+        {
+          "path": "https://github.com/.../firmware.bin",
+          "offset": 65536
+        }
+      ]
+    }
+  ]
+}
+```
+
+## 🚀 Release Process
+
+When creating a new release:
+
+1. **Build all boards:**
+   ```bash
+   ./build.sh all
+   ```
+
+2. **Copy artifacts to the artifacts directory:**
+   ```bash
+   mkdir -p artifacts
+   cp build/inkplate2/inkplate2-v*.bin artifacts/
+   cp build/inkplate5v2/inkplate5v2-v*.bin artifacts/
+   cp build/inkplate6flick/inkplate6flick-v*.bin artifacts/
+   cp build/inkplate10/inkplate10-v*.bin artifacts/
+   ```
+
+3. **Generate manifests:**
+   ```bash
+   ./scripts/generate_manifests.sh v0.13.0 artifacts flasher
+   ```
+
+4. **Create GitHub release and upload binaries:**
+   - Upload all `*.bin`, `*.bootloader.bin`, and `*.partitions.bin` files
+   - The manifests reference these files via GitHub release URLs
+
+5. **Commit the manifests:**
+   ```bash
+   git add flasher/manifest_*.json
+   git commit -m "Update flasher manifests for v0.13.0"
+   git push
+   ```
+
+## 🔐 CORS and Security
+
+The flasher fetches binaries directly from GitHub Releases. GitHub serves files with appropriate CORS headers, allowing the Web Serial API to download and flash them.
+
+## 📱 Browser Support
+
+The Web Serial API is supported in:
+- ✅ Chrome 89+
+- ✅ Edge 89+
+- ✅ Opera 75+
+- ❌ Firefox (not supported)
+- ❌ Safari (not supported)
+
+## 🐛 Troubleshooting
+
+### Manifest not loading
+- Check that the manifest file exists in the flasher directory
+- Verify the GitHub release URLs are correct
+- Check browser console for CORS errors
+
+### Flashing fails
+- Ensure device is in bootloader mode (usually automatic)
+- Try pressing reset button before flashing
+- Check that USB cable supports data transfer
+- Verify serial port drivers are installed
+
+### Testing with local binaries
+Due to browser security restrictions, you cannot directly flash from `file://` URLs. Use a local web server and ensure files are served with correct MIME types.
+
+## 📚 References
+
+- [ESP Web Tools Documentation](https://esphome.github.io/esp-web-tools/)
+- [Web Serial API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Serial_API)
+- [ESP32 Flash Layout](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/partition-tables.html)

--- a/flasher/index.html
+++ b/flasher/index.html
@@ -1,0 +1,513 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Inkplate Dashboard Web Flasher</title>
+    <meta
+      name="description"
+      content="Easily flash Inkplate Dashboard firmware directly from your browser using Web Serial API"
+    />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="color-scheme" content="dark light" />
+    <style>
+      * {
+        box-sizing: border-box;
+      }
+      
+      body {
+        font-family: -apple-system, system-ui, BlinkMacSystemFont, "Segoe UI",
+          Roboto, Ubuntu, sans-serif;
+        padding: 0;
+        margin: 0;
+        line-height: 1.6;
+        background-color: #f5f5f5;
+      }
+      
+      .header {
+        background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+        color: white;
+        padding: 2rem 1rem;
+        text-align: center;
+        box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+      }
+      
+      .header h1 {
+        margin: 0;
+        font-size: 2.5rem;
+        font-weight: 700;
+      }
+      
+      .header p {
+        margin: 0.5rem 0 0 0;
+        font-size: 1.1rem;
+        opacity: 0.95;
+      }
+      
+      .content {
+        max-width: 800px;
+        margin: 2rem auto;
+        padding: 0 1rem;
+      }
+      
+      .card {
+        background: white;
+        border-radius: 12px;
+        padding: 2rem;
+        margin-bottom: 2rem;
+        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+      }
+      
+      .card h2 {
+        margin-top: 0;
+        color: #333;
+        font-size: 1.5rem;
+        border-bottom: 2px solid #667eea;
+        padding-bottom: 0.5rem;
+      }
+      
+      .card h3 {
+        color: #555;
+        font-size: 1.2rem;
+        margin-top: 1.5rem;
+      }
+      
+      .board-selection {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+        gap: 1rem;
+        margin: 1.5rem 0;
+      }
+      
+      .board-option {
+        position: relative;
+      }
+      
+      .board-option input[type="radio"] {
+        position: absolute;
+        opacity: 0;
+      }
+      
+      .board-option label {
+        display: block;
+        padding: 1.5rem 1rem;
+        border: 2px solid #ddd;
+        border-radius: 8px;
+        text-align: center;
+        cursor: pointer;
+        transition: all 0.3s ease;
+        background: white;
+        font-weight: 500;
+      }
+      
+      .board-option label:hover {
+        border-color: #667eea;
+        background: #f8f9ff;
+        transform: translateY(-2px);
+        box-shadow: 0 4px 8px rgba(102, 126, 234, 0.2);
+      }
+      
+      .board-option input[type="radio"]:checked + label {
+        border-color: #667eea;
+        background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+        color: white;
+        font-weight: 600;
+      }
+      
+      .board-icon {
+        font-size: 2rem;
+        margin-bottom: 0.5rem;
+        display: block;
+      }
+      
+      .install-button-container {
+        text-align: center;
+        margin: 2rem 0;
+      }
+      
+      esp-web-install-button {
+        display: inline-block;
+      }
+      
+      esp-web-install-button.hidden {
+        display: none;
+      }
+      
+      .alert {
+        padding: 1rem;
+        border-radius: 8px;
+        margin: 1rem 0;
+      }
+      
+      .alert-info {
+        background: #e3f2fd;
+        border-left: 4px solid #2196f3;
+        color: #1565c0;
+      }
+      
+      .alert-warning {
+        background: #fff3e0;
+        border-left: 4px solid #ff9800;
+        color: #e65100;
+      }
+      
+      .alert strong {
+        display: block;
+        margin-bottom: 0.5rem;
+      }
+      
+      .instructions {
+        background: #f8f9fa;
+        border-radius: 8px;
+        padding: 1.5rem;
+        margin: 1rem 0;
+      }
+      
+      .instructions ol {
+        margin: 0;
+        padding-left: 1.5rem;
+      }
+      
+      .instructions li {
+        margin: 0.5rem 0;
+      }
+      
+      .features {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+        gap: 1rem;
+        margin: 1.5rem 0;
+      }
+      
+      .feature {
+        padding: 1rem;
+        background: #f8f9fa;
+        border-radius: 8px;
+        text-align: center;
+      }
+      
+      .feature-icon {
+        font-size: 2rem;
+        margin-bottom: 0.5rem;
+      }
+      
+      .footer {
+        text-align: center;
+        padding: 2rem 1rem;
+        color: #666;
+        border-top: 1px solid #ddd;
+        margin-top: 3rem;
+      }
+      
+      .footer a {
+        color: #667eea;
+        text-decoration: none;
+        font-weight: 500;
+      }
+      
+      .footer a:hover {
+        text-decoration: underline;
+      }
+      
+      .version-badge {
+        display: inline-block;
+        background: #667eea;
+        color: white;
+        padding: 0.25rem 0.75rem;
+        border-radius: 12px;
+        font-size: 0.85rem;
+        font-weight: 600;
+        margin-left: 0.5rem;
+      }
+      
+      code {
+        background: #f4f4f4;
+        padding: 0.2rem 0.4rem;
+        border-radius: 4px;
+        font-family: 'Courier New', monospace;
+        font-size: 0.9em;
+      }
+      
+      @media (prefers-color-scheme: dark) {
+        body {
+          background-color: #1a1a1a;
+          color: #e0e0e0;
+        }
+        
+        .card {
+          background: #2d2d2d;
+          box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+        }
+        
+        .card h2 {
+          color: #e0e0e0;
+        }
+        
+        .card h3 {
+          color: #c0c0c0;
+        }
+        
+        .board-option label {
+          background: #2d2d2d;
+          border-color: #444;
+          color: #e0e0e0;
+        }
+        
+        .board-option label:hover {
+          background: #3a3a4f;
+          border-color: #667eea;
+        }
+        
+        .alert-info {
+          background: #1a2332;
+          color: #64b5f6;
+        }
+        
+        .alert-warning {
+          background: #332a1a;
+          color: #ffb74d;
+        }
+        
+        .instructions {
+          background: #2d2d2d;
+        }
+        
+        .feature {
+          background: #2d2d2d;
+        }
+        
+        .footer {
+          border-top-color: #444;
+          color: #999;
+        }
+        
+        code {
+          background: #1a1a1a;
+          color: #e0e0e0;
+        }
+      }
+      
+      @media (max-width: 600px) {
+        .header h1 {
+          font-size: 1.75rem;
+        }
+        
+        .board-selection {
+          grid-template-columns: 1fr;
+        }
+        
+        .features {
+          grid-template-columns: 1fr;
+        }
+      }
+    </style>
+    <script
+      type="module"
+      src="https://unpkg.com/esp-web-tools@10/dist/web/install-button.js?module"
+    ></script>
+  </head>
+  <body>
+    <div class="header">
+      <h1>📱 Inkplate Dashboard</h1>
+      <p>Web-based firmware flasher</p>
+    </div>
+
+    <div class="content">
+      <div class="card">
+        <h2>🎯 Select Your Inkplate Device</h2>
+        
+        <div class="alert alert-info">
+          <strong>ℹ️ Before you start:</strong>
+          Make sure your Inkplate device is connected via USB cable to your computer.
+        </div>
+
+        <div class="alert alert-warning" id="local-test-warning" style="display: none;">
+          <strong>🧪 Local Testing Mode</strong>
+          You're running in local testing mode. The flasher will use binaries from your local build directory instead of GitHub releases.
+        </div>
+
+        <div class="board-selection">
+          <div class="board-option">
+            <input type="radio" name="board" id="inkplate2" value="inkplate2" />
+            <label for="inkplate2">
+              <span class="board-icon">📟</span>
+              Inkplate 2
+            </label>
+          </div>
+          
+          <div class="board-option">
+            <input type="radio" name="board" id="inkplate5v2" value="inkplate5v2" />
+            <label for="inkplate5v2">
+              <span class="board-icon">📱</span>
+              Inkplate 5 V2
+            </label>
+          </div>
+          
+          <div class="board-option">
+            <input type="radio" name="board" id="inkplate6flick" value="inkplate6flick" />
+            <label for="inkplate6flick">
+              <span class="board-icon">📲</span>
+              Inkplate 6 Flick
+            </label>
+          </div>
+          
+          <div class="board-option">
+            <input type="radio" name="board" id="inkplate10" value="inkplate10" />
+            <label for="inkplate10">
+              <span class="board-icon">🖥️</span>
+              Inkplate 10
+            </label>
+          </div>
+        </div>
+
+        <div class="install-button-container">
+          <esp-web-install-button class="hidden" manifest="">
+            <button slot="activate" class="install-btn">
+              Install Inkplate Dashboard
+            </button>
+          </esp-web-install-button>
+        </div>
+
+        <div class="alert alert-warning" id="no-support-warning" style="display: none;">
+          <strong>⚠️ Browser not supported</strong>
+          This flasher requires a browser with Web Serial API support. Please use:
+          <ul>
+            <li>Google Chrome (version 89+)</li>
+            <li>Microsoft Edge (version 89+)</li>
+            <li>Opera (version 75+)</li>
+          </ul>
+          Safari and Firefox are not currently supported.
+        </div>
+      </div>
+
+      <div class="card">
+        <h2>📋 Features</h2>
+        <div class="features">
+          <div class="feature">
+            <div class="feature-icon">🔄</div>
+            <strong>MQTT Dashboard</strong>
+            <p>Real-time data display</p>
+          </div>
+          <div class="feature">
+            <div class="feature-icon">🌐</div>
+            <strong>WiFi Portal</strong>
+            <p>Easy network setup</p>
+          </div>
+          <div class="feature">
+            <div class="feature-icon">🔋</div>
+            <strong>Battery Optimized</strong>
+            <p>Deep sleep support</p>
+          </div>
+          <div class="feature">
+            <div class="feature-icon">⚙️</div>
+            <strong>Configurable</strong>
+            <p>Web-based config</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="card">
+        <h2>📚 How to Flash</h2>
+        <div class="instructions">
+          <ol>
+            <li>Select your Inkplate device model above</li>
+            <li>Click the "Install Inkplate Dashboard" button</li>
+            <li>In the popup, select your device's serial port</li>
+            <li>Wait for the installation to complete (2-3 minutes)</li>
+            <li>After flashing, the device will restart automatically</li>
+            <li>Look for a WiFi network named <code>Inkplate-XXXXXX</code></li>
+            <li>Connect to it and configure your settings at <code>http://192.168.4.1</code></li>
+          </ol>
+        </div>
+      </div>
+
+      <div class="card">
+        <h2>❓ Troubleshooting</h2>
+        <h3>Can't see the serial port?</h3>
+        <ul>
+          <li>Make sure the USB cable is properly connected</li>
+          <li>Try a different USB cable (some cables are charge-only)</li>
+          <li>Install the <a href="https://www.silabs.com/developers/usb-to-uart-bridge-vcp-drivers" target="_blank">CP210x USB driver</a></li>
+          <li>On Linux, you may need to add your user to the <code>dialout</code> group</li>
+        </ul>
+
+        <h3>Flash failed or stuck?</h3>
+        <ul>
+          <li>Try pressing the reset button on your Inkplate before starting</li>
+          <li>Close any other programs using the serial port (Arduino IDE, PlatformIO, etc.)</li>
+          <li>Try a different USB port</li>
+          <li>Refresh this page and try again</li>
+        </ul>
+
+        <h3>Device won't start after flashing?</h3>
+        <ul>
+          <li>Press the reset button on the device</li>
+          <li>Disconnect and reconnect the USB cable</li>
+          <li>If using battery power, make sure it's charged</li>
+        </ul>
+      </div>
+
+      <div class="card">
+        <h2>🔗 Resources</h2>
+        <ul>
+          <li>📖 <a href="https://github.com/jantielens/inkplate-dashboard" target="_blank">GitHub Repository</a></li>
+          <li>📄 <a href="https://github.com/jantielens/inkplate-dashboard/blob/main/docs/user/README.md" target="_blank">Documentation</a></li>
+          <li>🐛 <a href="https://github.com/jantielens/inkplate-dashboard/issues" target="_blank">Report Issues</a></li>
+          <li>💬 <a href="https://github.com/jantielens/inkplate-dashboard/discussions" target="_blank">Discussions</a></li>
+        </ul>
+      </div>
+    </div>
+
+    <div class="footer">
+      <p>
+        <strong>Inkplate Dashboard</strong> by 
+        <a href="https://github.com/jantielens" target="_blank">Jan Tielens</a>
+      </p>
+      <p>
+        Powered by 
+        <a href="https://esphome.github.io/esp-web-tools/" target="_blank">ESP Web Tools</a>
+        &bull;
+        Inkplate devices by 
+        <a href="https://soldered.com/product-category/inkplate/" target="_blank">Soldered Electronics</a>
+      </p>
+    </div>
+
+    <script>
+      // Check for Web Serial API support
+      if (!navigator.serial) {
+        document.getElementById('no-support-warning').style.display = 'block';
+      }
+
+      // Detect if running in local/testing mode
+      const isLocal = window.location.hostname === 'localhost' || 
+                     window.location.hostname === '127.0.0.1' ||
+                     window.location.hostname.includes('github.dev');
+      
+      if (isLocal) {
+        document.getElementById('local-test-warning').style.display = 'block';
+        console.log('🧪 Running in local testing mode - using local binaries');
+      }
+
+      // Handle board selection
+      const installButton = document.querySelector('esp-web-install-button');
+      const boardRadios = document.querySelectorAll('input[name="board"]');
+      
+      boardRadios.forEach(radio => {
+        radio.addEventListener('change', (e) => {
+          const boardId = e.target.value;
+          
+          // For local testing, use the _local manifest which points to ../build/ files
+          const manifestSuffix = isLocal ? '_local' : '';
+          installButton.manifest = `./manifest_${boardId}${manifestSuffix}.json`;
+          installButton.classList.remove('hidden');
+          
+          console.log(`Selected board: ${boardId}, Using manifest: manifest_${boardId}${manifestSuffix}.json`);
+        });
+      });
+
+      // Add event listeners for install button
+      installButton.addEventListener('state-changed', (e) => {
+        console.log('State changed:', e.detail);
+      });
+    </script>
+  </body>
+</html>

--- a/scripts/generate_manifests.sh
+++ b/scripts/generate_manifests.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Generate ESP Web Tools manifest JSON files for each board
+# Usage: generate_manifests.sh <tag> <artifacts_dir> <output_dir>
+set -euo pipefail
+
+TAG=${1:-}
+ARTIFACTS_DIR=${2:-artifacts}
+OUTPUT_DIR=${3:-flasher}
+
+if [ -z "$TAG" ]; then
+  echo "Usage: $0 <tag> [artifacts_dir] [output_dir]"
+  exit 2
+fi
+
+# Remove 'v' prefix from tag if present
+VERSION="${TAG#v}"
+
+# ensure jq exists
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required but not installed. Please install jq."
+  exit 1
+fi
+
+# Friendly display names for boards
+declare -A NAMES
+NAMES[inkplate2]="Inkplate 2"
+NAMES[inkplate5v2]="Inkplate 5 V2"
+NAMES[inkplate10]="Inkplate 10"
+NAMES[inkplate6flick]="Inkplate 6 Flick"
+
+# Create output directory
+mkdir -p "$OUTPUT_DIR"
+
+# ESP32 memory offsets (in decimal)
+BOOTLOADER_OFFSET=4096      # 0x1000
+PARTITIONS_OFFSET=32768     # 0x8000
+FIRMWARE_OFFSET=65536       # 0x10000
+
+echo "Generating ESP Web Tools manifests for version ${VERSION}..."
+
+# Find all main firmware binaries and generate manifests
+for firmware_bin in "$ARTIFACTS_DIR"/*-v*.bin; do
+  [ -f "$firmware_bin" ] || continue
+  
+  # Skip bootloader and partition files
+  if [[ "$firmware_bin" == *".bootloader.bin" ]] || [[ "$firmware_bin" == *".partitions.bin" ]]; then
+    continue
+  fi
+  
+  filename=$(basename "$firmware_bin")
+  # Extract board name (e.g., "inkplate2" from "inkplate2-v0.13.0.bin")
+  board=$(echo "$filename" | sed -E 's/-v.*//')
+  
+  # Construct filenames for all parts
+  bootloader_file="${board}-v${VERSION}.bootloader.bin"
+  partitions_file="${board}-v${VERSION}.partitions.bin"
+  firmware_file="${board}-v${VERSION}.bin"
+  
+  # Check if all required files exist
+  if [ ! -f "$ARTIFACTS_DIR/$bootloader_file" ]; then
+    echo "⚠️  Warning: Bootloader not found for $board: $bootloader_file"
+    continue
+  fi
+  
+  if [ ! -f "$ARTIFACTS_DIR/$partitions_file" ]; then
+    echo "⚠️  Warning: Partitions file not found for $board: $partitions_file"
+    continue
+  fi
+  
+  # Generate URLs
+  base_url="https://github.com/jantielens/inkplate-dashboard/releases/download/${TAG}"
+  bootloader_url="${base_url}/${bootloader_file}"
+  partitions_url="${base_url}/${partitions_file}"
+  firmware_url="${base_url}/${firmware_file}"
+  
+  display_name="${NAMES[$board]:-$board}"
+  manifest_file="$OUTPUT_DIR/manifest_${board}.json"
+  
+  # Create manifest JSON
+  jq -n \
+    --arg name "Inkplate Dashboard for ${display_name}" \
+    --arg version "$VERSION" \
+    --arg bootloader_url "$bootloader_url" \
+    --argjson bootloader_offset "$BOOTLOADER_OFFSET" \
+    --arg partitions_url "$partitions_url" \
+    --argjson partitions_offset "$PARTITIONS_OFFSET" \
+    --arg firmware_url "$firmware_url" \
+    --argjson firmware_offset "$FIRMWARE_OFFSET" \
+    '{
+      name: $name,
+      version: $version,
+      home_assistant_domain: "inkplate_dashboard",
+      new_install_prompt_erase: true,
+      builds: [{
+        chipFamily: "ESP32",
+        parts: [
+          { path: $bootloader_url, offset: $bootloader_offset },
+          { path: $partitions_url, offset: $partitions_offset },
+          { path: $firmware_url, offset: $firmware_offset }
+        ]
+      }]
+    }' > "$manifest_file"
+  
+  echo "✅ Generated manifest: $manifest_file"
+done
+
+echo ""
+echo "Manifest generation complete!"
+echo "Manifests saved to: $OUTPUT_DIR/"

--- a/scripts/prepare_release.sh
+++ b/scripts/prepare_release.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Prepare release artifacts and manifests
+# Usage: prepare_release.sh <version>
+set -euo pipefail
+
+VERSION=${1:-}
+
+if [ -z "$VERSION" ]; then
+  echo "Usage: $0 <version>"
+  echo "Example: $0 v0.13.0"
+  exit 2
+fi
+
+# Remove 'v' prefix if present, then add it back for consistency
+VERSION="${VERSION#v}"
+TAG="v${VERSION}"
+
+echo "=== Preparing Release $TAG ==="
+echo ""
+
+# Step 1: Build all boards
+echo "📦 Step 1: Building all boards..."
+./build.sh all
+if [ $? -ne 0 ]; then
+  echo "❌ Build failed!"
+  exit 1
+fi
+echo "✅ All boards built successfully"
+echo ""
+
+# Step 2: Prepare artifacts directory
+echo "📁 Step 2: Preparing artifacts directory..."
+ARTIFACTS_DIR="artifacts"
+rm -rf "$ARTIFACTS_DIR"
+mkdir -p "$ARTIFACTS_DIR"
+
+# Copy all binaries (firmware, bootloader, partitions) to artifacts
+for board_dir in build/*/; do
+  board=$(basename "$board_dir")
+  echo "  Copying artifacts for $board..."
+  
+  # Copy versioned files
+  cp "$board_dir"/${board}-v${VERSION}.bin "$ARTIFACTS_DIR/" 2>/dev/null || true
+  cp "$board_dir"/${board}-v${VERSION}.bootloader.bin "$ARTIFACTS_DIR/" 2>/dev/null || true
+  cp "$board_dir"/${board}-v${VERSION}.partitions.bin "$ARTIFACTS_DIR/" 2>/dev/null || true
+done
+
+# List artifacts
+echo ""
+echo "Artifacts prepared:"
+ls -lh "$ARTIFACTS_DIR"
+echo ""
+
+# Step 3: Generate manifests
+echo "📝 Step 3: Generating ESP Web Tools manifests..."
+./scripts/generate_manifests.sh "$TAG" "$ARTIFACTS_DIR" flasher
+echo ""
+
+# Step 4: Generate latest.json
+echo "📄 Step 4: Generating latest.json..."
+./scripts/generate_latest_json.sh "$TAG" "$ARTIFACTS_DIR" flasher/latest.json
+echo ""
+
+# Summary
+echo "=========================================="
+echo "✅ Release preparation complete!"
+echo "=========================================="
+echo ""
+echo "Next steps:"
+echo "1. Review artifacts in: $ARTIFACTS_DIR/"
+echo "2. Test flasher locally:"
+echo "   cd flasher && python3 -m http.server 8000"
+echo "3. Create GitHub release with tag: $TAG"
+echo "4. Upload all files from $ARTIFACTS_DIR/ to the release"
+echo "5. Commit updated manifests:"
+echo "   git add flasher/"
+echo "   git commit -m 'Update flasher for $TAG'"
+echo "   git push"
+echo ""
+echo "Binary sizes:"
+for bin in "$ARTIFACTS_DIR"/*-v${VERSION}.bin; do
+  [ -f "$bin" ] && du -h "$bin"
+done

--- a/scripts/setup_local_testing.sh
+++ b/scripts/setup_local_testing.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Setup local testing environment for web flasher
+# This copies build artifacts to flasher/builds/ and creates local manifests
+
+set -euo pipefail
+
+echo "🧪 Setting up local testing environment..."
+echo ""
+
+FLASHER_DIR="flasher"
+BUILD_DIR="build"
+
+# Create builds directory structure
+mkdir -p "$FLASHER_DIR/builds"
+
+# Copy binaries for each board
+for board in inkplate2 inkplate5v2 inkplate6flick inkplate10; do
+  echo "📦 Setting up $board..."
+  
+  # Create board directory
+  mkdir -p "$FLASHER_DIR/builds/$board"
+  
+  # Copy binaries if they exist
+  if [ -d "$BUILD_DIR/$board" ]; then
+    cp "$BUILD_DIR/$board/${board}-v"*.bin "$FLASHER_DIR/builds/$board/" 2>/dev/null || echo "  ⚠️  No binaries found for $board (run ./build.sh $board first)"
+    
+    # Create local manifest
+    if [ -f "$FLASHER_DIR/builds/$board/${board}-v0.13.0.bin" ]; then
+      cat > "$FLASHER_DIR/manifest_${board}_local.json" << EOF
+{
+  "name": "Inkplate Dashboard for ${board} (Local Test)",
+  "version": "0.13.0",
+  "home_assistant_domain": "inkplate_dashboard",
+  "new_install_prompt_erase": true,
+  "builds": [
+    {
+      "chipFamily": "ESP32",
+      "parts": [
+        {
+          "path": "./builds/${board}/${board}-v0.13.0.bootloader.bin",
+          "offset": 4096
+        },
+        {
+          "path": "./builds/${board}/${board}-v0.13.0.partitions.bin",
+          "offset": 32768
+        },
+        {
+          "path": "./builds/${board}/${board}-v0.13.0.bin",
+          "offset": 65536
+        }
+      ]
+    }
+  ]
+}
+EOF
+      echo "  ✅ Created local manifest and copied binaries"
+      ls -lh "$FLASHER_DIR/builds/$board/" | grep -E "\.bin$" | awk '{print "     - " $9 " (" $5 ")"}'
+    fi
+  else
+    echo "  ⚠️  Build directory not found: $BUILD_DIR/$board"
+  fi
+  echo ""
+done
+
+echo "=========================================="
+echo "✅ Local testing environment ready!"
+echo "=========================================="
+echo ""
+echo "To test the flasher:"
+echo "  cd flasher && python3 -m http.server 8080"
+echo ""
+echo "Then open: http://localhost:8080"
+echo ""
+echo "Note: Make sure to use a Chromium-based browser"
+echo "      (Chrome, Edge, or Opera) for Web Serial API support"


### PR DESCRIPTION
## Overview

This PR implements a browser-based firmware flasher using ESP Web Tools, enabling users to flash Inkplate devices directly from their web browser without installing any software.

## Key Features

- ✅ **Browser-based flashing** using ESP Web Tools v10
- ✅ **All 4 Inkplate boards** supported (2, 5 V2, 6 Flick, 10)
- ✅ **Three-part ESP32 flashing** (bootloader, partitions, firmware) matching arduino-cli behavior
- ✅ **Automated manifest generation** in release workflow
- ✅ **Local testing infrastructure** for development
- ✅ **Comprehensive documentation**

## Changes

### Core Implementation
- `flasher/index.html` - Web flasher UI with ESP Web Tools integration
- `flasher/README.md` - User documentation
- `build.sh` - Modified to generate 3 versioned binaries per board

### Scripts
- `scripts/generate_manifests.sh` - Generate ESP Web Tools manifest files
- `scripts/generate_latest_json.sh` - Enhanced with bootloader/partition URLs
- `scripts/prepare_release.sh` - Manual release preparation helper
- `scripts/setup_local_testing.sh` - Local testing environment setup

### Workflows
- `.github/workflows/release.yml` - Updated to generate manifests and commit to main-flasher
- `.github/workflows/flasher-static-site.yml` - Auto-triggers on release completion

### Documentation
- `docs/dev/WEB_FLASHER.md` - Technical documentation (~500 lines)
- `docs/dev/RELEASE_WORKFLOW.md` - Complete workflow documentation
- `docs/dev/BUILD_SYSTEM.md` - Updated with binary generation info

### Version
- Bumped to **v0.14.0**
- Updated `CHANGELOG.md`

## Testing

Tested locally with inkplate6flick:
- ✅ Manifest generation
- ✅ Local flashing via Web Serial API
- ✅ Three-part flash process

## Deployment Flow

After merge:
1. Tag `v0.14.0` on main
2. Release workflow builds firmware + generates manifests
3. Manifests committed to `main-flasher` branch
4. Flasher deployment auto-triggers
5. Users can flash from GitHub Pages

## Browser Support

- Chrome 89+, Edge 89+, Opera 75+
- Requires HTTPS and Web Serial API
- Firefox/Safari not supported (no Web Serial API)

## Documentation

See comprehensive docs:
- `docs/dev/WEB_FLASHER.md` - Technical architecture
- `docs/dev/RELEASE_WORKFLOW.md` - Complete workflow guide

Closes #[issue-number-if-any]